### PR TITLE
Fix missing include on Windows

### DIFF
--- a/include/Frog.hpp
+++ b/include/Frog.hpp
@@ -2,6 +2,7 @@
 #define Frog_hpp
 
 #include <memory>
+#include <string>
 #include <stdio.h>
 #include <box2d/box2d.h>
 #include <SDL.h>


### PR DESCRIPTION
It failed to compile on windows due to this missing header